### PR TITLE
提取难度分数函数，对齐难度和提示字样

### DIFF
--- a/src/PDF版题目与答案/tex/question01.tex
+++ b/src/PDF版题目与答案/tex/question01.tex
@@ -21,6 +21,7 @@
     1 4 9
 \end{tcolorbox}
 
-$\bullet ~ $\textbf{难度}：\ding{72} \ding{72} \ding{73} \ding{73} \ding{73}
-
-$~~~$\textbf{提示}：\mintinline{c++}{T& operator|(T& v, const T& f) }。
+\begin{itemize}
+    \item \textbf{难度}： \hardscore{2} \\ 
+    \textbf{提示}：\mintinline{c++}{T& operator|(T& v, const T& f) }。
+\end{itemize}

--- a/src/PDF版题目与答案/tex/question02.tex
+++ b/src/PDF版题目与答案/tex/question02.tex
@@ -32,6 +32,8 @@
     π：3.141593
 \end{tcolorbox}
 
-$\bullet ~ $\textbf{难度}：\ding{72} \ding{72} \ding{73} \ding{73} \ding{73}
 
-$~~~$\textbf{提示}：C++11 用户定义字面量、C++20 format 库。
+\begin{itemize}
+    \item \textbf{难度}： \hardscore{2} \\ 
+    \textbf{提示}：C++11 用户定义字面量、C++20 format 库。
+\end{itemize}

--- a/src/PDF版题目与答案/tex/question03.tex
+++ b/src/PDF版题目与答案/tex/question03.tex
@@ -39,8 +39,9 @@
     1/10
 \end{tcolorbox}
 
-$\bullet ~ $\textbf{难度}：\ding{72} \ding{72} \ding{72} \ding{73} \ding{73}
-
-$~~~$\textbf{提示}：std::formatter。
+\begin{itemize}
+    \item \textbf{难度}： \hardscore{3} \\
+    \textbf{提示}：std::formatter。
+\end{itemize}
 
 禁止面向结果编程，使用宏等等方式，本题主要考察和学习 format 库，记得测试至少三个不同编译器。

--- a/src/PDF版题目与答案/tex/utility.tex
+++ b/src/PDF版题目与答案/tex/utility.tex
@@ -1,0 +1,14 @@
+
+\newcommand{\hardscore}[1]{
+    \newcount\starcount
+    \starcount=0
+    \loop
+        \ifnum\starcount<5
+            \ifnum\starcount<#1
+            \ding{72}
+            \else
+            \ding{73}
+            \fi
+        \advance\starcount by 1
+    \repeat
+}

--- a/src/PDF版题目与答案/现代C++题目.tex
+++ b/src/PDF版题目与答案/现代C++题目.tex
@@ -25,6 +25,8 @@
 
 \date{\today}
 
+\input{tex/utility.tex}
+
 \begin{document}
 \maketitle
 


### PR DESCRIPTION
我又来了，这次换了个方式，提取出来当头文件使
此外，这次好像发现用item有点额外好处，就是可以自动对齐有点和没点的。

然后看你的喜好有三种不同的对齐方式，分别是：（我现在改的是第一种）
用 \\ 换行
<img width="211" alt="图片" src="https://github.com/Mq-b/Loser-HomeWork/assets/16556163/323c626e-0d81-4fbd-b9aa-ca484e0c4823">

直接空一行
<img width="209" alt="图片" src="https://github.com/Mq-b/Loser-HomeWork/assets/16556163/854c276d-8d51-4d43-9db9-f7c036b9b441">

把下面的也放进itemize
<img width="212" alt="图片" src="https://github.com/Mq-b/Loser-HomeWork/assets/16556163/ccdb7868-8b94-4302-8395-a82adbd1d540">
