### PR TITLE
添加 DevCom 上 `catch(auto)` 的 bug 报告链接

### DIFF
--- a/src/卢瑟日经/catch(auto)的问题.md
+++ b/src/卢瑟日经/catch(auto)的问题.md
@@ -77,4 +77,6 @@ int main()
 
 ## 总结
 
-暂时没啥结果，这种没有使用意义，应该不会是编译器扩展，可能就是个 bug。
+暂时没啥结果，这种没有使用意义，应该不会是编译器扩展，可能就是个 bug[^1]。
+
+[^1]: [Invalid `catch(auto)` syntax is accepted - Developer Community](https://developercommunity.visualstudio.com/t/Invalid-catchauto-syntax-is-accepted/1570658)


### PR DESCRIPTION
这毫无疑问是个 bug：

[DevCom-1570658](https://developercommunity.visualstudio.com/t/Invalid-catchauto-syntax-is-accepted/1570658)