### PR TITLE
14 题：改进利用链接符号名的做法

### DIFF
--- a/src/群友提交/第14题/F.v.S..cpp
+++ b/src/群友提交/第14题/F.v.S..cpp
@@ -1,0 +1,14 @@
+#include<iostream>
+
+namespace ss {
+    int a = 0;
+}
+
+int main() {
+    extern int _ZN2ss1aE;
+#ifdef _MSC_VER
+#pragma comment(linker, "/alternatename:?_ZN2ss1aE@@3HA=?a@ss@@3HA")
+#endif
+    _ZN2ss1aE = 100;
+    std::cout << ss::a << '\n';
+}


### PR DESCRIPTION
这里改进的写法看上去不需要修改 `ss`，可能更“干净”一点。

原理：
- Itanium ABI 上变量 `ss::a` 的重整名为 `_ZN2ss1aE`。
- 在 MSVC 上需要用 `#pragma` 告诉链接器使用 MSVC ABI 的重整名 `?a@ss@@3HA`。

[Godbolt link](https://godbolt.org/z/bnG4T4vd1)

还有另一个作弊的写法，不过大概不符合要求：
```C++
#include<iostream>

namespace ss {
    int a = 0;
}

int main() {
    enum ss { a = 100 };
    std::cout << ss::a << '\n';
}
```