### PR TITLE
`msvc stl` 修复了 `std::transform_reduce` 的问题，更改措辞

### DIFF
--- a/src/C++CoreGuidelines/第3章-接口.md
+++ b/src/C++CoreGuidelines/第3章-接口.md
@@ -224,8 +224,9 @@ std::size_t res = std::transform_reduce(
 );//res 值为 21。
 ```
 
-> 事实上原书给的上面这段代码是有问题的，无法在 `msvc` 通过编译，这里使用的是 **`0`** 做初始值，有窄化转换，[msvc 使用的是 `{}` 初始化](https://github.com/microsoft/STL/blob/adea8d5ae280cafb91ae69b8dfaecd1c37a847d9/stl/inc/execution#L4235)。，检测到了，于是编译错误。（但是需要注意，不是简单的 `{}` 检测的问题，msvc 的实现和其他 stl 从根本上就不一样）
-> 这里其实可以算作是 msvc 的 bug，这个场景需要良构 这里应该把 0 换成 `Oull` （基于当前 64 位环境），或者标准够高使用 `0uz`，再或者直接 `std::size_t{0}`。
+> 如果使用 msvc 进行编译，此代码在 [`VS2022 17.10 Preview`](https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710-preview-1) 之前无法通过，这是 msvc 的 [***BUG***](https://github.com/microsoft/STL/pull/4260)。
+这在于之前的 [msvc stl 实现](https://github.com/microsoft/STL/blob/adea8d5ae280cafb91ae69b8dfaecd1c37a847d9/stl/inc/execution#L4235)，使用的是 `{}` 进行初始化，因为有窄化转换，所以无法通过编译。这两个 Lambda 表达式都是返回 `std::size_t` 类型的，与 **`0`** 的 `int` 不同。
+不过即使标准允许，也建议不使用 `0`，而是改成 `0uz` 或 `std::size_t{0}`，避免隐式转换与警告。
 
 函数 `std::transform_reduce`  先将每个字符串变换为它的长度 `[](std::string s) {return s.size(); }` , 并将二元可调用实体 `[](std::size_t a, std::size_t b) {return a + b; },` 应用到结果的范围上。求和的初始值是 0。整个计算是并行的 `std::execution::par`。
 


### PR DESCRIPTION
#294