### PR TITLE
外部仓库代码片段使用永久链接

### DIFF
--- a/src/卢瑟日经/STL中类的字节大小.md
+++ b/src/卢瑟日经/STL中类的字节大小.md
@@ -97,7 +97,7 @@ private:
     id            _M_id;
 ```
 
-id 就是 libstdc++ 实现的 [`std::thread::id`](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/std_thread.h#L92-L120)，那么问题继续，这个 `std::thread::id` 类型又是保有了什么数据成员呢？
+id 就是 libstdc++ 实现的 [`std::thread::id`](https://github.com/gcc-mirror/gcc/blob/3e3d115c946944c81d8231dfbe778d4dae26cbb7/libstdc%2B%2B-v3/include/bits/std_thread.h#L92-L120)，那么问题继续，这个 `std::thread::id` 类型又是保有了什么数据成员呢？
 
 ```cpp
 native_handle_type  _M_thread;


### PR DESCRIPTION
避免日后代码移动出现错位问题。