### PR TITLE
第十四题 使用 asm 指定符号名

### DIFF
--- a/src/群友提交/第14题/Matrix-A-3.cpp
+++ b/src/群友提交/第14题/Matrix-A-3.cpp
@@ -1,3 +1,4 @@
+//!msvc
 #include<iostream>
 #include<atomic>
 

--- a/src/群友提交/第14题/Matrix-A-3.cpp
+++ b/src/群友提交/第14题/Matrix-A-3.cpp
@@ -1,0 +1,13 @@
+#include<iostream>
+#include<atomic>
+
+namespace ss {
+    int a = 0;
+}
+
+int main() {
+    extern int b asm("_ZN2ss1aE");
+    b = 100;
+    std::atomic_thread_fence(std::memory_order_acq_rel);
+    std::cout << ss::a << '\n'; 
+}


### PR DESCRIPTION
解释 asm("..")可以手动指定符号名。
使用```std::atomic_thread_fence(std::memory_order_acq_rel);```是为了禁止将读取```ss::a```优化到写入 b 之前

不支持msvc，因为msvc x64 不支持 asm 功能

https://gcc.godbolt.org/z/WYqcc56r7